### PR TITLE
Add ProGuard rules to keep WhatTheStackInitializer

### DIFF
--- a/what-the-stack/consumer-rules.pro
+++ b/what-the-stack/consumer-rules.pro
@@ -1,0 +1,3 @@
+-keep class com.haroldadmin.whatthestack.WhatTheStackInitializer {
+  <init>();
+}


### PR DESCRIPTION
Without this my app consistently crashes due to the class being discarded by R8.

<details>
<summary>Stacktrace</summary>

```
 D  Shutting down VM
 E  FATAL EXCEPTION: main
 E  Process: dev.msfjarvis.aps, PID: 2800
 E  java.lang.RuntimeException: Unable to get provider androidx.startup.InitializationProvider: androidx.startup.StartupException: java.lang.ClassNotFoundException: com
    .haroldadmin.whatthestack.WhatTheStackInitializer
 E      at android.app.ActivityThread.installProvider(ActivityThread.java:7135)
 E      at android.app.ActivityThread.installContentProviders(ActivityThread.java:6675)
 E      at android.app.ActivityThread.handleBindApplication(ActivityThread.java:6592)
 E      at android.app.ActivityThread.access$1300(ActivityThread.java:233)
 E      at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1896)
 E      at android.os.Handler.dispatchMessage(Handler.java:106)
 E      at android.os.Looper.loop(Looper.java:223)
 E      at android.app.ActivityThread.main(ActivityThread.java:7523)
 E      at java.lang.reflect.Method.invoke(Native Method)
 E      at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:592)
 E      at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:941)
 E  Caused by: androidx.startup.StartupException: java.lang.ClassNotFoundException: com.haroldadmin.whatthestack.WhatTheStackInitializer
 E      at androidx.startup.InitializationProvider.onCreate(InitializationProvider.java:22)
 E      at android.content.ContentProvider.attachInfo(ContentProvider.java:2388)
 E      at android.content.ContentProvider.attachInfo(ContentProvider.java:2358)
 E      at android.app.ActivityThread.installProvider(ActivityThread.java:7130)
 E      ... 10 more
 E  Caused by: java.lang.ClassNotFoundException: com.haroldadmin.whatthestack.WhatTheStackInitializer
 E      at java.lang.Class.classForName(Native Method)
 E      at java.lang.Class.forName(Class.java:454)
 E      at java.lang.Class.forName(Class.java:379)
 E      at androidx.startup.InitializationProvider.onCreate(InitializationProvider.java:18)
 E      ... 13 more
 E  Caused by: java.lang.ClassNotFoundException: com.haroldadmin.whatthestack.WhatTheStackInitializer
 E      ... 17 more
```

</details>