### PR TITLE
Don't override default uncaught exception handler

### DIFF
--- a/what-the-stack/src/main/java/com/haroldadmin/whatthestack/WhatTheStack.kt
+++ b/what-the-stack/src/main/java/com/haroldadmin/whatthestack/WhatTheStack.kt
@@ -32,7 +32,8 @@ internal object InitializationManager {
     private val connection = WhatTheStackConnection(
         onConnected = { binder ->
             val messenger = Messenger(binder)
-            val exceptionHandler = WhatTheStackExceptionHandler(messenger)
+            val defaultHandler = Thread.getDefaultUncaughtExceptionHandler()
+            val exceptionHandler = WhatTheStackExceptionHandler(messenger, defaultHandler)
             Thread.setDefaultUncaughtExceptionHandler(exceptionHandler)
         }
     )

--- a/what-the-stack/src/main/java/com/haroldadmin/whatthestack/WhatTheStackExceptionHandler.kt
+++ b/what-the-stack/src/main/java/com/haroldadmin/whatthestack/WhatTheStackExceptionHandler.kt
@@ -12,7 +12,8 @@ import androidx.core.os.bundleOf
  */
 
 internal class WhatTheStackExceptionHandler(
-    private val service: Messenger
+    private val service: Messenger,
+    private val defaultHandler: Thread.UncaughtExceptionHandler?
 ) : Thread.UncaughtExceptionHandler {
     override fun uncaughtException(t: Thread, e: Throwable) {
 
@@ -27,6 +28,6 @@ internal class WhatTheStackExceptionHandler(
             )
         })
 
-        Process.killProcess(Process.myPid())
+        defaultHandler?.uncaughtException(t, e) ?: Process.killProcess(Process.myPid())
     }
 }


### PR DESCRIPTION
If you register a custom UncaughtExceptionHandler you should delegate to
the currently set default UncaughtExceptionHandler.
This allows for chaining of multiple different UncaughtExceptionHandlers,
e.g. WhatTheStack and Crashlytics.