### PR TITLE
Print every exception before sending it across IPC

### DIFF
--- a/what-the-stack/src/main/java/com/haroldadmin/whatthestack/WhatTheStackExceptionHandler.kt
+++ b/what-the-stack/src/main/java/com/haroldadmin/whatthestack/WhatTheStackExceptionHandler.kt
@@ -2,7 +2,6 @@ package com.haroldadmin.whatthestack
 
 import android.os.Message
 import android.os.Messenger
-import android.util.Log
 import androidx.core.os.bundleOf
 
 /**

--- a/what-the-stack/src/main/java/com/haroldadmin/whatthestack/WhatTheStackExceptionHandler.kt
+++ b/what-the-stack/src/main/java/com/haroldadmin/whatthestack/WhatTheStackExceptionHandler.kt
@@ -2,6 +2,7 @@ package com.haroldadmin.whatthestack
 
 import android.os.Message
 import android.os.Messenger
+import android.util.Log
 import androidx.core.os.bundleOf
 
 /**
@@ -19,6 +20,7 @@ internal class WhatTheStackExceptionHandler(
     private val defaultHandler: Thread.UncaughtExceptionHandler?,
 ) : Thread.UncaughtExceptionHandler {
     override fun uncaughtException(t: Thread, e: Throwable) {
+        e.printStackTrace()
         val exceptionData = e.process()
         serviceMessenger.send(
             Message().apply {


### PR DESCRIPTION
This PR fixes the issue where very large stacktraces override the original exception in WhatTheStack.

- WhatTheStack uses a multi-process setup to show the exception screen after a crash
- The thrown exception is parsed in the host application's process, and then sent across to a different process that runs `WhatTheStackService`.
- Android places a limit on the size of IPC messages. Some exceptions lead to very large stack traces (such as `StackOverflowException`), which cause this limit to be exceeded.
- In such cases, the process of transferring the parsed exception data to another process causes _another_ exception to be thrown, which then overwrites the original exception.

It's not easy to workaround the IPC message size limitation. This PR adds code to log the original exception to make it's information is available through the logcat.

Fixes #31
