### PR TITLE
Bump dependencies to newer milestones

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,7 +45,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion "1.0.5"
+        kotlinCompilerExtensionVersion libs.versions.composeCompiler.get()
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 buildscript {
     ext.buildConfig = [
             "applicationId": "com.haroldadmin.crashyapp",
-            "compileSdk"   : 31,
+            "compileSdk"   : 33,
             "minSdk"       : 21,
             "targetSdk"    : 31,
             "versionCode"  : 1,

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-kotlin = "1.5.31"
-agp = "7.0.3"
+kotlin = "1.7.20"
+agp = "7.4.2"
 ktlint = "10.1.0"
 appCompat = "1.3.0"
 coreTest = "2.0.0"
@@ -18,14 +18,17 @@ mockk = "1.9.3"
 robolectric = "4.3.1"
 startup = "1.0.0"
 composeActivity = "1.3.1"
-compose = "1.0.5"
-accompanist = "0.21.3-beta"
+composeUi = "1.3.3"
+composeCompiler = "1.3.2"
+composeFoundation = "1.3.1"
+composeMaterial = "1.3.1"
+accompanist = "0.28.0"
 
 [libraries]
 
 composeActivity = { module = "androidx.activity:activity-compose", version.ref = "composeActivity" }
-composeMaterial = { module = "androidx.compose.material:material", version.ref = "compose" }
-composeTooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
+composeMaterial = { module = "androidx.compose.material:material", version.ref = "composeMaterial" }
+composeTooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "composeUi" }
 accompanistSysUi = { module = "com.google.accompanist:accompanist-systemuicontroller", version.ref = "accompanist" }
 accompanistInsets = { module = "com.google.accompanist:accompanist-insets", version.ref = "accompanist" }
 agp = { module = "com.android.tools.build:gradle", version.ref = "agp" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jan 14 11:19:34 IST 2020
+#Thu Mar 02 18:03:21 CET 2023
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-all.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/what-the-stack/build.gradle
+++ b/what-the-stack/build.gradle
@@ -40,7 +40,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion libs.versions.compose.get()
+        kotlinCompilerExtensionVersion libs.versions.composeCompiler.get()
     }
 }
 


### PR DESCRIPTION
Bump compose and accompanist dependencies to newer versions in order to remain compatible with apps that use later version of those libraries. Since newer accompanist requires compose 1.3.1, I've also updated those

I've also separated compose into sub-versions, since `foundation` ,`material` ,`compiler` and `ui` are not following the same versioning. This also required updating `kotlin` and `AGP` to newer version. This should also help any future development

Fixes #33 